### PR TITLE
Fix: get rid of deprecation warnings

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/xwiki/main/doc/search.png</screenshot>
 	<dependencies>
 		<php min-version="8.0"/>
-		<nextcloud min-version="25" max-version="30"/>
+		<nextcloud min-version="27" max-version="31"/>
 	</dependencies>
 	<navigations>
 		<navigation>

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -11,6 +11,8 @@ use OCP\AppFramework\Http\EmptyContentSecurityPolicy;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\Http\Client\IClientService;
 use OCP\IURLGenerator;
 use OCP\IL10N;
@@ -134,15 +136,14 @@ class PageController extends Controller {
 	}
 
 	/**
-	 * CAUTION: the @Stuff turns off security checks; for this page no admin is
+	 * CAUTION: the following attributes turn off security checks; for this page no admin is
 	 *          required and no CSRF check. If you don't know what CSRF is, read
 	 *          it up in the docs or you might create a security hole. This is
 	 *          basically the only required method to add this exemption, don't
 	 *          add it to any other method if you don't exactly know what it does
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function index() {
 		$xwikiURL = '';
 		$xwikiEditURL = '';

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -12,6 +12,8 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\NotFoundResponse;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\Http\Client\IClientService;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -55,10 +57,8 @@ class SettingsController extends Controller {
 		$this->settings = $settings;
 	}
 
-	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	*/
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function addToken(): RedirectResponse {
 		$instanceUrl = $this->request->getParam('i');
 		$token = $this->request->getParam('token');
@@ -71,9 +71,7 @@ class SettingsController extends Controller {
 		);
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function requestToken(): ?RedirectResponse {
 		$instanceUrl = $this->request->getParam('i');
 		$instance = $this->settings->getInstance($instanceUrl);
@@ -101,10 +99,8 @@ class SettingsController extends Controller {
 		return null;
 	}
 
-	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	*/
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function oidcRedirect(): RedirectResponse {
 		$state = $this->request->getParam('state');
 		$code = $this->request->getParam('code');
@@ -189,9 +185,7 @@ class SettingsController extends Controller {
 		);
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function deleteToken(): RedirectResponse {
 		$instanceUrl = $this->request->getParam('i');
 		$this->settings->setUserToken($instanceUrl, '');
@@ -203,9 +197,7 @@ class SettingsController extends Controller {
 		);
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function setDisabled(): JSONResponse {
 		$instanceUrl = $this->request->getParam('i');
 		$value = $this->request->getParam('v') === 'true';
@@ -213,9 +205,7 @@ class SettingsController extends Controller {
 		return new JSONResponse(['ok' => true]);
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function setUserValue(): JSONResponse {
 		$key = $this->request->getParam('k');
 		$value = $this->request->getParam('v');
@@ -291,9 +281,7 @@ class SettingsController extends Controller {
 		}
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function pingInstance(): JSONResponse {
 		$url = Instance::fixURL($this->request->getParam('url'));
 		if (empty($url)) {

--- a/lib/Search/Provider.php
+++ b/lib/Search/Provider.php
@@ -25,6 +25,8 @@ class Provider implements IProvider {
 	public SettingsManager $settings;
 	private IClientService $clientService;
 
+	private IURLGenerator $urlGenerator;
+
 	public function __construct(SettingsManager $settings, IClientService $clientService, IURLGenerator $urlGenerator) {
 		$this->settings = $settings;
 		$this->clientService = $clientService;


### PR DESCRIPTION
- changed Controller annotations to attributes (bumps minimal NC version to 27)
- declared dynamic property ´urlGenerator´ in Searchprovider