### PR TITLE
Feat: prepare for Transifex use

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,10 @@
+[main]
+host     = https://www.transifex.com
+lang_map = th_TH: th, ja_JP: ja, bg_BG: bg, cs_CZ: cs, fi_FI: fi, hu_HU: hu, nb_NO: nb, sk_SK: sk
+
+[o:nextcloud:p:nextcloud:r:xwiki]
+file_filter = translationfiles/<lang>/xwiki.po
+source_file = translationfiles/templates/integxwikiration_documenso.pot
+source_lang = en
+type        = PO
+

--- a/l10n/.l10nignore
+++ b/l10n/.l10nignore
@@ -1,0 +1,2 @@
+js/
+vendor/


### PR DESCRIPTION
This is needed for the use of Transifex as a translation tool (see https://docs.nextcloud.com/server/latest/developer_manual/basics/front-end/l10n.html#adding-translations)