### PR TITLE
Prepare v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0]
+
+### Added 
+
+- Support for Nextcloud 31
+- translations via Transifex
+- preview widgets for links to XWiki pages
+- a smart picker for XWiki Links
+
+### Fixed 
+
+- PDF download working again
+- deprecated PHP attributes replaced
+
+### Removed
+
+- Support for Nextcloud 25 & 26
+
+
 ## [0.1.2] - 2024-04-11
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>XWiki</name>
 	<summary>XWiki Integration for Nextcloud</summary>
 	<description><![CDATA[This application allows you to search and display your XWiki content right from Nextcloud. XWiki is a powerful development platform that allows you to customize the wiki to your specific needs. Using structured data and in-page-scripting you can create macros and applications that allow you to extend the capabilities of your wiki. Note: full functionality requires the Nextcloud extension on XWiki (11.10 or later required).]]></description>
-	<version>0.1.2</version>
+	<version>1.0.0</version>
 	<licence>agpl</licence>
 	<author mail="raphael.jakse@xwiki.com" homepage="https://xwiki.org">Raphaël Jakse</author>
 	<category>integration</category>


### PR DESCRIPTION
## [1.0.0]

### Added 

- Support for Nextcloud 31
- translations via Transifex
- preview widgets for links to XWiki pages
- a smart picker for XWiki Links

### Fixed 

- PDF download working again
- deprecated PHP attributes replaced

### Removed

- Support for Nextcloud 25 & 26